### PR TITLE
Update OAuth2Error.swift

### DIFF
--- a/CocOAuth/OAuth2Error.swift
+++ b/CocOAuth/OAuth2Error.swift
@@ -27,7 +27,7 @@ public struct OAuth2Error: Error {
         
         static func fromString(_ errorCode: String) -> ErrorKind {
             var error = ErrorKind.internalError
-            switch errorCode {
+            switch errorCode.lowercased() {
                 
             case "invalid_request":
                 error = invalidRequest


### PR DESCRIPTION
- convert error_code to lower case to avoid missmatches when error code