### PR TITLE
add fallback for getting error description

### DIFF
--- a/CocOAuth/OAuth2Client.swift
+++ b/CocOAuth/OAuth2Client.swift
@@ -209,7 +209,9 @@ internal class OAuth2Client{
                 }
                 var errorDescription = ""
                 if let eDescription = jsonDic["error_description"] as? String{
-                        errorDescription = eDescription
+                    errorDescription = eDescription
+                } else if let eMessage = jsonDic["message"] as? String{
+                    errorDescription = eMessage
                 }
                 print(errorCode)
                 error = OAuth2Error(errorMessage: errorDescription, kind: OAuth2Error.ErrorKind.fromString(errorCode), error: nil)


### PR DESCRIPTION
 - add fallback for getting errordescription if default json-key: error_description does not exist then look for json-key: message